### PR TITLE
Add Docker support and basic unit tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+.venv
+logs
+*.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Default command
+CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: ${PGDATABASE:-nfl}
+      POSTGRES_USER: ${PGUSER:-postgres}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-postgres}
+    ports:
+      - "${PGPORT:-5432}:5432"
+  app:
+    build: .
+    env_file:
+      - .env
+    depends_on:
+      - db
+    command: ["python", "main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-nfl_data_py 
-pandas 
-numpy 
-SQLAlchemy 
-psycopg2-binary 
+nfl_data_py
+pandas
+numpy
+SQLAlchemy
+psycopg2-binary
 python-dotenv
 requests
 beautifulsoup4
 lxml
 matplotlib
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import sys
+import types
+import pandas as pd
+from pathlib import Path
+
+# ensure project root on path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# provide a lightweight stub for nfl_data_py to satisfy imports during tests
+fake_nfl = types.SimpleNamespace(
+    import_team_desc=lambda: pd.DataFrame(columns=["team_abbr","team_name"]),
+    import_weekly_data=lambda years: pd.DataFrame(),
+    import_schedules=lambda years: pd.DataFrame(),
+    import_seasonal_rosters=lambda years, columns=None: pd.DataFrame(columns=columns or []),
+    import_betting_lines=lambda years: pd.DataFrame(),
+)
+sys.modules.setdefault("nfl_data_py", fake_nfl)
+
+# minimal stub for sqlalchemy used in modules
+def _sqlalchemy_text(s):
+    return s
+def _create_engine(*args, **kwargs):
+    class Dummy:
+        def connect(self):
+            raise RuntimeError("stub")
+    return Dummy()
+fake_sqlalchemy = types.SimpleNamespace(text=_sqlalchemy_text, create_engine=_create_engine)
+sys.modules.setdefault("sqlalchemy", fake_sqlalchemy)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+
+@pytest.mark.skipif(not os.getenv("PGHOST"), reason="Database not configured")
+def test_database_connection():
+    from db import get_engine, ensure_schema, create_tables
+    engine = get_engine()
+    with engine.connect() as con:
+        con.execute("SELECT 1")
+    ensure_schema(engine)
+    create_tables(engine)

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import facts
+
+def test_build_fact_all(monkeypatch):
+    monkeypatch.setattr(facts, "YEARS", [2024])
+    data = [
+        {
+            "game_id": "gid1",
+            "season": 2024,
+            "week": 1,
+            "team": "KC",
+            "opponent": "LV",
+            "time_slot": "Sunday Night",
+            "player_id": "1",
+            "player_name": "A",
+            "position": "QB",
+            "passing_yards": 200,
+            "passing_tds": 2,
+            "interceptions": 1,
+        },
+        {
+            "game_id": "gid1",
+            "season": 2024,
+            "week": 1,
+            "team": "KC",
+            "opponent": "LV",
+            "time_slot": "Sunday Night",
+            "player_id": "1",
+            "player_name": "A",
+            "position": "QB",
+            "passing_yards": 300,
+            "passing_tds": 4,
+            "interceptions": 0,
+        },
+    ]
+    wk = pd.DataFrame(data)
+    fact = facts.build_fact_all(wk)
+    assert len(fact) == 1
+    row = fact.iloc[0]
+    assert row["passing_yards_avg"] == 250
+    assert row["passing_tds_avg"] == 3
+    assert row["interceptions_avg"] == 0.5
+    assert row["season_range"] == "2024–2024"

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,0 +1,7 @@
+from lines import _normalize_book_name
+
+def test_normalize_book_name():
+    assert _normalize_book_name("draft kings") == "DraftKings"
+    assert _normalize_book_name("Fan duel") == "FanDuel"
+    assert _normalize_book_name("Fanatics Sportsbook") == "Fanatics"
+    assert _normalize_book_name("Other") == "Other"

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1,0 +1,7 @@
+from teams import team_alias_map
+
+def test_team_alias_map_basic():
+    m = team_alias_map()
+    assert m["los angeles rams"] == "LAR"
+    assert m["oakland raiders"] == "LV"
+    assert m["seattle"] == "SEA"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import math
+import pandas as pd
+from utils import mk_game_id, time_slot, coerce_numeric
+
+def test_mk_game_id():
+    assert mk_game_id(2024, 1, "KC", "LV") == "2024_01_KC_LV"
+
+def test_time_slot():
+    assert time_slot("Sunday", 13) == "Sunday Early Window"
+    assert time_slot("Monday", 20) == "Monday"
+    assert time_slot("Thursday", 20) == "Thursday"
+    assert time_slot("Sunday", 10) == "Sunday Morning"
+    assert time_slot("Sunday", 16) == "Sunday Late Window"
+    assert time_slot("Sunday", 21) == "Sunday Night"
+    assert time_slot("Wednesday", 12) == "Unknown"
+    assert time_slot(None, None) == "Unknown"
+
+def test_coerce_numeric():
+    df = pd.DataFrame({"a": ["1", "x"]})
+    coerce_numeric(df, ["a"])
+    assert df["a"].iloc[0] == 1.0
+    assert math.isnan(df["a"].iloc[1])


### PR DESCRIPTION
## Summary
- containerize the ETL app with a Dockerfile and docker-compose including Postgres
- add `.dockerignore` and update requirements with pytest
- introduce pytest suite covering utility helpers, line normalization, team alias mapping, fact aggregation, and optional DB connectivity

## Testing
- `pip install pandas numpy` *(partial dependency install; full `pip install -r requirements.txt` fails building pandas tied to `nfl_data_py`)*
- `pip install python-dotenv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cafeb8708329b5a1d7b51a7ea969